### PR TITLE
Fix Linux config file location

### DIFF
--- a/client_config.md
+++ b/client_config.md
@@ -8,7 +8,7 @@ Run the file called `config_directory.bat`, that can be find in the Teeworlds di
 
 ### Linux
 
-The config file is located in `~/.teeworlds`.
+The config file is located in `~/.local/share/teeworlds/settings07.cfg`.
 
 ### Mac OSX
 

--- a/client_config.md
+++ b/client_config.md
@@ -1,6 +1,6 @@
 # Client Configuration
 
-To find the configuration file for Teeworlds, you can read this guide. If you want to configure the client, check out [Client Settings](client_settings.md). If you want to find the client commands available, see [Client Commands](client_commands.md). The client configuration file is always called `settings.cfg` but located in different locations depending on the operating system.
+To find the configuration file for Teeworlds, you can read this guide. If you want to configure the client, check out [Client Settings](client_settings.md). If you want to find the client commands available, see [Client Commands](client_commands.md). The client configuration file is always called `settings07.cfg` but located in different locations depending on the operating system.
 
 ### Windows
 
@@ -8,8 +8,8 @@ Run the file called `config_directory.bat`, that can be find in the Teeworlds di
 
 ### Linux
 
-The config file is located in `~/.local/share/teeworlds/settings07.cfg`.
+The config file is located in `~/.local/share/teeworlds/`.
 
 ### Mac OSX
 
-The config file is located in `~/Library/Application Support/Teeworlds`.
+The config file is located in `~/Library/Application Support/Teeworlds/`.


### PR DESCRIPTION
I'm not sure if the actual file name should be included in the path or if the path should point to the directory the config file is located in. Also in the main body it says "The config file is always called `settings.cfg`, whereas on Linux at least it's called `settings07.cfg`. I don't know if that is true on all platforms.