### PR TITLE
Add demo player hotkeys, add demo marker command, fix headlines

### DIFF
--- a/client_commands.md
+++ b/client_commands.md
@@ -21,9 +21,6 @@ All these commands can be executed in the console. To open the console, press th
 |`screenshot`|	screenshot|	Take a screenshot|
 |`rcon`|	rcon command|	Execute the command in rcon|
 |`rcon_auth`|	rcon_auth password|	Authenticate with rcon|
-|`play`|	play filename|	Play the file in the demo player|
-|`record`|	record filename|	Start a recording to the specified file|
-|`stoprecord`| stoprecord|	Stop the recording|
 |`add_favorite`|	add_favorite host:port|	Add the server as a favorite|
 |`remove_favourite`|	remove_favourite host:port|	Remove the server from your favourites|
 |`add_friend`|	add_friend name clan|	Add the player to your friendlist|
@@ -70,6 +67,15 @@ All these commands can be executed in the console. To open the console, press th
 |`dump_remote_console`|	dump\_remote\_console|	Dump the remote console|
 |`team`|	team team_id|	Switch to the specified team (0 = red, 1 = blue, -1 = spectators)|
 |`kill`|	kill|	Kill yourself|
+
+### Demo recorder/player commands
+
+|Command |  Syntax | Description|
+| ------ | ------- | ---------- |
+|`play`|	play filename|	Play the file in the demo player|
+|`record`|	record filename|	Start a recording to the specified file (omit filename to use timestamp)|
+|`stoprecord`| stoprecord|	Stop the recording|
+|`add_demomarker`| add_demomarker|	Add a demo marker at the current time (while recording a demo)|
 
 ### Startup commands
 

--- a/demo_player.md
+++ b/demo_player.md
@@ -1,0 +1,13 @@
+# Demo Player
+
+## Hotkeys
+
+| Hotkey | Description|
+| ------ | ---------- |
+|Esc|Show/hide the demo player menu|
+|Ctrl|Show/hide the seek bar|
+|Space|Pause/Resume playback|
+|+/-|Increase/Decrease playback speed|
+|Left/Right arrow|Skip backwards/forwards 5 seconds|
+|Shift+Left/Right arrow|Skip backwards/forwards 30 seconds|
+|Ctrl+Left/Right arrow|Skip to the previous/next timeline marker (or the beginning/end of the demo if no more markers)|

--- a/help.md
+++ b/help.md
@@ -5,7 +5,7 @@ Your question might already been asked by others. Try searching though the [FAQ]
 
 ## 2. Go through the Documentation
 
-###Rules
+### Rules
 
 [Support Rules](rules/support_rules.md)
 
@@ -15,11 +15,11 @@ Your question might already been asked by others. Try searching though the [FAQ]
 
 [Server Hosting Rules](rules/server_rules.md)
 
-###Game Information
+### Game Information
 
 [CTF Scoring](ctf_scoring.md)
 
-####Client
+#### Client
 
 [Client Settings](client_settings.md)
 
@@ -27,7 +27,9 @@ Your question might already been asked by others. Try searching though the [FAQ]
 
 [Client Config](client_config.md)
 
-####Server
+[Demo Player](demo_player.md)
+
+#### Server
 
 [Server Setup](server_setup.md)
 
@@ -38,7 +40,7 @@ Your question might already been asked by others. Try searching though the [FAQ]
 [Server Tuning](server_tuning.md)
 
 
-###Hacking and Development
+### Hacking and Development
 
 [Hacking on source](hacking.md)
 
@@ -47,7 +49,7 @@ Your question might already been asked by others. Try searching though the [FAQ]
 [Source Formatting](nomenclature.md)
 
 
-###Other
+### Other
 
 [Licensing, Modifications and Donations](licensing_misc.md)
 


### PR DESCRIPTION
- Add `demo_player.md` with documentation of the hotkeys and link it in `help.md`.
- Add the "add_demomarker" command to the list of client command and move the demo player/recorder command to a separate table.
- Fix headlines in `help.md`.
Closes #40.