### PR TITLE
Fix headers, remove obsolete compiling_everything

### DIFF
--- a/client_commands.md
+++ b/client_commands.md
@@ -2,11 +2,11 @@
 
 There are lots of client commands that can be executed in the console, or in the configuration file. This doc shows them all. If you look for client settings, read the [Client Settings](client_settings.md) doc. To find out how to find the config file, read the [Client Config](client_config.md) doc.
 
-### Console
+## Console
 
 All these commands can be executed in the console. To open the console, press the console-key (f1 is default).
 
-### Engine
+## Engine
 
 |Command |  Syntax | Description|
 | ------ | ------- | ---------- |
@@ -22,7 +22,7 @@ All these commands can be executed in the console. To open the console, press th
 |`+toggle`|`+toggle config_option value1 value2`|Toggle config value via keypress|
 |`snd_toggle`|`snd_toggle`|Toggle sounds on and off|
 
-### Servers
+## Servers
 
 |Command |  Syntax | Description|
 | ------ | ------- | ---------- |
@@ -34,7 +34,7 @@ All these commands can be executed in the console. To open the console, press th
 |`add_favorite`|`add_favorite host:port [password]`|Add the server as a favorite, optionally saving the password|
 |`remove_favorite`|`remove_favorite host:port`|Remove the server from your favorites|
 
-### Gameplay
+## Gameplay
 
 |Command |  Syntax | Description|
 | ------ | ------- | ---------- |
@@ -56,7 +56,7 @@ All these commands can be executed in the console. To open the console, press th
 |`ready_change`|`ready_change`|Change ready state|
 |`kill`|`kill`|Respawn|
 
-### Social
+## Social
 
 |Command |  Syntax | Description|
 | ------ | ------- | ---------- |
@@ -75,7 +75,7 @@ All these commands can be executed in the console. To open the console, press th
 |`add_ignore`|`add_ignore name clan`|Add the player to your ignorelist|
 |`remove_ignore`|`remove_ignore name clan`|Remove the player from your ignorelist|
 
-### Key binds
+## Key binds
 
 |Command |  Syntax | Description|
 | ------ | ------- | ---------- |
@@ -84,7 +84,7 @@ All these commands can be executed in the console. To open the console, press th
 |`unbindall`|`unbindall`|Unbind all the keys|
 |`binds`|`binds`|List all key binds|
 
-### Spectating
+## Spectating
 |Command |  Syntax | Description|
 | ------ | ------- | ---------- |
 |`+spectate`|`+spectate`|Show the spectator mode selector|
@@ -93,7 +93,7 @@ All these commands can be executed in the console. To open the console, press th
 |`spectate_previous`|`spectate_previous`|Spectate the previous player|
 |`set_position`|`set_position index x y`|Set saved camera position at index to be the position (x, y)|
 
-### Console
+## Console
 
 |Command |  Syntax | Description|
 | ------ | ------- | ---------- |
@@ -104,7 +104,7 @@ All these commands can be executed in the console. To open the console, press th
 |`clear_remote_console`|`clear_remote_console`|Clear the remote console|
 |`dump_remote_console`|`dump_remote_console`|Write remote console contents to a text file|
 
-### Demo recorder/player
+## Demo recorder/player
 
 |Command |  Syntax | Description|
 | ------ | ------- | ---------- |
@@ -113,7 +113,7 @@ All these commands can be executed in the console. To open the console, press th
 |`stoprecord`|`stoprecord`|Stop the recording|
 |`add_demomarker`|`add_demomarker`|Add a demo marker at the current time (while recording a demo)|
 
-### Startup commands
+## Startup commands
 
 To start Teeworlds on Windows with the debug console open, use `teeworlds.exe -c` or `teeworlds.exe --console`.
 It is also possible to add the parameter to a windows shortcut.

--- a/client_config.md
+++ b/client_config.md
@@ -2,14 +2,14 @@
 
 To find the configuration file for Teeworlds, you can read this guide. If you want to configure the client, check out [Client Settings](client_settings.md). If you want to find the client commands available, see [Client Commands](client_commands.md). The client configuration file is always called `settings07.cfg` but located in different locations depending on the operating system.
 
-### Windows
+## Windows
 
 Run the file called `config_directory.bat`, that can be find in the Teeworlds directory, or enter `%APPDATA%\Teeworlds` in an Explorer window.
 
-### Linux
+## Linux
 
 The config file is located in `~/.local/share/teeworlds/`.
 
-### Mac OSX
+## Mac OSX
 
 The config file is located in `~/Library/Application Support/Teeworlds/`.

--- a/client_settings.md
+++ b/client_settings.md
@@ -2,7 +2,7 @@
 
 There are lots of client settings available, and this doc will guide you through them. If you are looking for client commands, read the [Client Commands](client_commands.md) doc. To find out how to find the config file, read the [Client Config](client_config.md) doc.
 
-### Engine
+## Engine
 
 | Setting       | Description   | Default value  |
 | ------------- | ------------- | -------------- |
@@ -25,7 +25,7 @@ There are lots of client settings available, and this doc will guide you through
 |`cl_show_welcome`|Show initial set-up dialog|1|
 |`cl_version_server`|Server to use to check for new versions|`"version.teeworlds.com"`|
 
-### Player
+## Player
 
 | Setting       | Description   | Default value  |
 | ------------- | ------------- | -------------- |
@@ -52,7 +52,7 @@ There are lots of client settings available, and this doc will guide you through
 |`player_use_custom_color_hands`|Toggles usage of custom colors for hands|1|
 |`player_use_custom_color_marking`|Toggles usage of custom colors for marking|1|
 
-### Ingame
+## Ingame
 
 |Settings       | Description   | Default value  |
 | ------------- | ------------- | -------------- |
@@ -82,7 +82,7 @@ There are lots of client settings available, and this doc will guide you through
 |`cl_statboard_infos`|Mask of info to display on the global statboard|1259|
 |`cl_warning_teambalance`|Warn about team balance|1|
 
-#### Camera
+### Camera
 
 |Settings       | Description   | Default value  |
 | ------------- | ------------- | -------------- |
@@ -94,7 +94,7 @@ There are lots of client settings available, and this doc will guide you through
 |`cl_mouse_max_distance_dynamic`|Mouse max distance, in dynamic camera mode|1000|
 |`cl_mouse_max_distance_static`|Mouse max distance, in static camera mode|400|
 
-### Input
+## Input
 
 |Settings       | Description   | Default value  |
 | ------------- | ------------- | -------------- |
@@ -110,7 +110,7 @@ There are lots of client settings available, and this doc will guide you through
 |`ui_mousesens`|Mouse sensitivity for menus/editor|100|
 |`ui_joystick_sens`|Joystick sensitivity for menus/editor|100|
 
-### Graphics
+## Graphics
 
 |Settings       | Description   | Default value  |
 | ------------- | ------------- | -------------- |
@@ -134,7 +134,7 @@ There are lots of client settings available, and this doc will guide you through
 |`gfx_use_x11xrandr_wm`|Let SDL use the X11 XRandR window manager|1|
 |`gfx_vsync`|Activate VSync|1|
 
-### Sounds
+## Sounds
 
 |Settings       | Description   | Default value  |
 | ------------- | ------------- | -------------- |
@@ -147,7 +147,7 @@ There are lots of client settings available, and this doc will guide you through
 |`snd_rate`|Sound mixing rate|48000|
 |`snd_volume`|Sound volume|100|
 
-### Menu
+## Menu
 
 |Settings       | Description   | Default value  |
 | ------------- | ------------- | -------------- |
@@ -157,7 +157,7 @@ There are lots of client settings available, and this doc will guide you through
 |`cl_show_start_menu_images`|Show start menu images|1|
 |`cl_skip_start_menu`|Skip the start menu|0|
 
-#### Camera
+### Camera
 
 |Settings       | Description   | Default value  |
 | ------------- | ------------- | -------------- |
@@ -165,7 +165,7 @@ There are lots of client settings available, and this doc will guide you through
 |`cl_rotation_radius`|Menu camera rotation radius|30|
 |`cl_rotation_speed`|Menu camera rotations in seconds|40|
 
-### User interface
+## User interface
 
 |Settings       | Description   | Default value  |
 | ------------- | ------------- | -------------- |
@@ -178,7 +178,7 @@ There are lots of client settings available, and this doc will guide you through
 |`ui_settings_page`|Interface settings page|0|
 |`ui_wideview`|Extended menus GUI|0|
 
-### Server & Demo browser
+## Server & Demo browser
 
 The individual server browser filter settings are store separately in the file `ui_settings.json` in the same folder as the config file.
 
@@ -191,7 +191,7 @@ The individual server browser filter settings are store separately in the file `
 |`br_demo_sort_order`|Sort order (0 is ascending and 1 is descending) in the demo browser|0|
 |`br_max_requests`|Number of requests to use when refreshing server browser|25|
 
-### Editor
+## Editor
 
 | Setting       | Description   | Default value  |
 | ------------- | ------------- | -------------- |

--- a/compiling_everything_linux.md
+++ b/compiling_everything_linux.md
@@ -6,7 +6,7 @@
 
 Bam is the [build system made by matricks](http://matricks.github.io/bam/) used in Teeworlds.
 
-#### Setup
+## Setup
 1. Use your package manager (apt-get, emerge or whatever is used on your distribution) to install the following (you will need the header files):
     - gcc
     - g++
@@ -25,7 +25,7 @@ Bam is the [build system made by matricks](http://matricks.github.io/bam/) used 
     - `$ cd ..`
 
 
-#### Compiling
+## Compiling Teeworlds v0.7.x
 1. `cd teeworlds-version`
     - Changes to the teeworlds source directory
 2. `./bam/bam config`
@@ -47,7 +47,7 @@ Bam is the [build system made by matricks](http://matricks.github.io/bam/) used 
 4. The compiled game is located at `teeworlds-version/build/<arch>`
 
 
-# For Teeworlds v0.6.x and earlier
+## Compiling Teeworlds v0.6.x and earlier
 
 1. `cd teeworlds-version`
     - Changes to the teeworlds source directory

--- a/compiling_everything_mac.md
+++ b/compiling_everything_mac.md
@@ -6,7 +6,7 @@
 
 Bam is the [build system made by matricks](http://matricks.github.io/bam/) used in Teeworlds.
 
-#### Setup
+## Setup
 1. Install Xcode from the Appstore or install Xcode Command Line Tools `xcode-select --install`. 
 2. Install libsdl using [brew](https://brew.sh/) `brew install sdl2`
 3. Install Freetype using [brew](https://brew.sh/) `brew install freetype`
@@ -18,7 +18,7 @@ Bam is the [build system made by matricks](http://matricks.github.io/bam/) used 
     - `$ cd ..`
 
 
-#### Compiling
+## Compiling Teeworlds v0.7.x
 1. `cd teeworlds-version`
     - Changes to the teeworlds source directory
 2. `./bam/bam config`
@@ -39,7 +39,7 @@ Bam is the [build system made by matricks](http://matricks.github.io/bam/) used 
 4. The compiled game is located at `teeworlds-version/build/<arch>`
 
 
-# For Teeworlds v0.6.x and earlier
+## Compiling Teeworlds v0.6.x and earlier
 
 1. `cd teeworlds-version`
     - Changes to the teeworlds source directory

--- a/compiling_everything_windows.md
+++ b/compiling_everything_windows.md
@@ -4,8 +4,8 @@
 
 Bam is the [build system made by matricks](http://matricks.github.io/bam/) used in Teeworlds.
 
-# Windows (x64 and x86)
-### Setup (Using Microsoft Tools)
+## Setup (Using Microsoft Tools)
+
 1. Download and install [Visual Studio 2017 Community](https://visualstudio.microsoft.com/de/downloads/).
 2. Download and unzip [Teeworlds source](https://github.com/teeworlds/teeworlds/releases) or [Teeworlds latest source](https://github.com/teeworlds/teeworlds/archive/master.zip)
 3. Download and install [Python 3.x](https://www.python.org/download/)
@@ -13,8 +13,8 @@ Bam is the [build system made by matricks](http://matricks.github.io/bam/) used 
     - Run `make_win64_msvc.bat` (or `make_win32_msvc.bat` for x86) to compile bam
     - **Note:** Bam does not recognise Visual Studio 2017. As a workaround, to compile bam, run the aforementioned batch script from the `x64 Native Tools Command Prompt` (or `x86 Native Tools Command Prompt` for x86)
 
-## For Teeworlds v0.7.x
-### Compiling
+## Compiling Teeworlds v0.7.x
+
 1. Run the `x64 Native Tools Command Prompt` (or `x86 Native Tools Command Prompt` for x86) from the start menu.
 2. `cd teeworlds-version`
     - Changes to the teeworlds source directory
@@ -34,9 +34,9 @@ Bam is the [build system made by matricks](http://matricks.github.io/bam/) used 
         - `.\bam\bam conf=release tools masterserver`
     - Flag `-f` will force a recompile
 5. The compiled game is located at `teeworlds-version\build\x86_64\` (or `teeworlds-version\build\x86\` for x86)
-    
-## For Teeworlds v0.6.x and earlier
-### Compiling
+
+## Compiling Teeworlds v0.6.x and earlier
+
 1. Run the `x64 Native Tools Command Prompt` (or `x86 Native Tools Command Prompt` for x86) from the start menu.
 2. `cd teeworlds-version`
     - Changes to the teeworlds source directory

--- a/ctf_scoring.md
+++ b/ctf_scoring.md
@@ -1,3 +1,5 @@
+# Capture the Flag (CTF) scoring
+
 ## Team score
 
 - +1 for taking the flag from the flag stand

--- a/help.md
+++ b/help.md
@@ -19,7 +19,7 @@ Your question might already been asked by others. Try searching though the [FAQ]
 
 [CTF Scoring](ctf_scoring.md)
 
-#### Client
+### Client
 
 [Client Settings](client_settings.md)
 
@@ -29,7 +29,7 @@ Your question might already been asked by others. Try searching though the [FAQ]
 
 [Demo Player](demo_player.md)
 
-#### Server
+### Server
 
 [Server Setup](server_setup.md)
 

--- a/nomenclature.md
+++ b/nomenclature.md
@@ -1,7 +1,6 @@
-#All code in teeworlds should match this code guidelines.
+# All code in teeworlds should match this code guidelines.
 
-
-### Brackets and Such
+## Brackets and Such
 
 Hardtabs, tabsize 4.
 
@@ -18,15 +17,15 @@ if(MyInt != 5)
 ContinueMyStuff();
 ```
 
-### Comments
+## Comments
 
 Use `//` style comments for most things. Larger blocks of comments can use `/* */` style but shouldn't be used inside function bodies.
 
-### Identifiers
+## Identifiers
 
 Use [CamelCase](http://en.wikipedia.org/wiki/CamelCase) with upper case on the first letter as well.
 
-### Variable Prefixes
+## Variable Prefixes
 
 `m_`
 
@@ -50,7 +49,7 @@ Fixed array
 
 Combine them appropriately.
 
-### Class Prefixes
+## Class Prefixes
 
 `C`
 
@@ -60,11 +59,11 @@ Class, CMyClass, This goes for structures as well.
 
 Interface, IMyClass
 
-### Null pointers
+## Null pointers
 
 Use `0` or `0x0` instead of `NULL`. Because Teeworlds uses C++03, `nullptr` does not work either.
 
-### Passing Variables
+## Passing Variables
 
 Pass by value for smaller things, const reference for larger objects. By pointer if the function needs to modify the object. Don't cast values as just a reference. If the function needs to modify it, use a pointer to show it as well.
 
@@ -76,7 +75,7 @@ void MyFunction(int *pMyVar);
 void MyFunction(int &pMyVar); // Never do this!
 ```
 
-### Examples
+## Examples
 
 ```
 class IMyInterface

--- a/reset_config.md
+++ b/reset_config.md
@@ -2,16 +2,16 @@
 
 This is done by deleting the configuration file called settings.cfg. This will force the game to use the predefined defaults within the executables.
 
-### Windows
+## Windows
 
 Double click on the config_directory.bat. This will take you to the directory where the config-file is stored. Delete the settings.cfg file.
 
-### Linux/*nix
+## Linux/\*nix
 
 The config-file is stored at `~/.teeworlds/settings.cfg`. Just run this command from a terminal to delete it.
 
 `# rm ~/.teeworlds/settings.cfg`
 
-### OSX
+## OSX
 
 Delete `settings.cfg` in `~/Library/Application Support/Teeworlds`.

--- a/server_commands.md
+++ b/server_commands.md
@@ -2,7 +2,7 @@
 
 To kick players from the server and to do other similar things, you have to use the server commands. This doc will show you these. If you want to know how to set up a server, read the [Server Setup](server_setup.md) doc. For server settings, see the [Server Settings](server_settings.md) doc.
 
-### Engine
+## Engine
 
 | Command | Syntax     | Description |
 | ------- | ---------- | ----------- |
@@ -23,7 +23,7 @@ To kick players from the server and to do other similar things, you have to use 
 |`tune_reset`|`tune_reset`|Reset all tuning variables to defaults|
 |`tunes`|`tunes`|List all tuning variables and their values|
 
-### Game
+## Game
 
 | Command | Syntax     | Description |
 | ------- | ---------- | ----------- |
@@ -38,7 +38,7 @@ To kick players from the server and to do other similar things, you have to use 
 |`shuffle_teams`|`shuffle_teams`|Shuffle the current teams|
 |`swap_teams`|`swap_teams`|Swap the current teams|
 
-### Players
+## Players
 
 | Command | Syntax     | Description |
 | ------- | ---------- | ----------- |
@@ -49,7 +49,7 @@ To kick players from the server and to do other similar things, you have to use 
 |`status`|`status`|List the player's id, ip, name and score|
 |`unban`|`unban ip`|Unban the ip|
 
-### Votes
+## Votes
 
 | Command | Syntax     | Description |
 | ------- | ---------- | ----------- |

--- a/server_settings.md
+++ b/server_settings.md
@@ -2,11 +2,11 @@
 
 There are lots of server settings to change all from the score limit, to the speed of the shotgun. This doc will show you what those are, not how to set up a server. Read the [Server Setup](server_setup.md) doc to learn that. For server commands, see the [Server Commands](server_commands.md) doc.
 
-### Physics
+## Physics
 
 To change the game's physics, read the [Server Tuning](server_tuning.md) doc.
 
-### Engine
+## Engine
 
 `*` means it can't be changed while running the server.
 
@@ -41,7 +41,7 @@ To change the game's physics, read the [Server Tuning](server_tuning.md) doc.
 |`sv_skill_level`|Skill level shown in serverbrowser (0 = casual, 1 = normal, 2 = competitive)|1|
 |`sv_spamprotection`|Spam protection|1|
 
-### Game
+## Game
 
 | Settings | Description | Default |
 | -------- | ----------- | ------- |
@@ -68,7 +68,7 @@ To change the game's physics, read the [Server Tuning](server_tuning.md) doc.
 |`sv_vote_spectate_rejoindelay`|How many minutes to wait before a player can rejoin after being moved to spectators by vote|3|
 |`sv_warmup`|Number of seconds to do warmup before match starts (0 disables, -1 all players ready)|0|
 
-### External console
+## External console
 
 | Settings | Description | Default |
 | -------- | ----------- | ------- |

--- a/server_setup.md
+++ b/server_setup.md
@@ -2,13 +2,13 @@
 
 This doc will guide you through the basics of setting up a server on Linux and Windows.
 
-### Port forwarding
+## Port forwarding
 
 If you want other players to be able to play on the server via internet, you have to forward a port to the server (default is 8303). http://portforward.com/ has a lot information on how to do this.
 
 The master server will warn if players can't connect.
 
-### Configuring the server
+## Configuring the server
 
 To configure the server you need to create a .cfg-file so that the server knows what to do. Use your favorite text editor to create a config that uses the following syntax:
 
@@ -21,19 +21,19 @@ To find the available settings, read the [Server Settings](server_settings.md) d
 
 You can find example configurations below.
 
-### Starting the server
+## Starting the server
 
 To start the server you must specify a config for it to load. This is done by adding the flag `-f` to the server start command, like this:
 `teeworlds_srv -f serverconfig.cfg`
 
-##### Windows
+### Windows
 
 Start the command tool by pressing `Win`+`R` write `cmd` followed by enter, and use the command `cd` to navigate to the teeworlds directory.
 
 When you get there, start the server by typing `teeworlds_srv.exe -f serverconfig.cfg`
 where you replace `serverconfig.cfg` with the name of your config file.
 
-##### Linux
+### Linux
 
 Open up a terminal and use the command `cd` to enter the teeworlds directory.
 
@@ -41,13 +41,13 @@ To start the server, type
  `teeworlds_srv -f serverconfig.cfg`
 where you replace `serverconfig.cfg` with the name of your config file.
 
-### Remote console
+## Remote console
 
 To be able to execute server commands while playing, there is a remote console. To open it, press `F2` (or the key you have chosen). You will now be asked to enter a password. If you did not set up a password in your config, a random one will have been generated: check the server log.
 
 To find out what commands that are available on the server, read the [Server Commands](server_commands.md) doc.
 
-### Support
+## Support
 
 If you have any questions, read the [FAQ](support/faq.md). If you can't find an answer, please use the support forum.
 

--- a/server_tuning.md
+++ b/server_tuning.md
@@ -5,7 +5,7 @@ Tuning is a way to edit physics and weapon settings so that the server is more c
 `tune gravity 1.0`
 where you replace `gravity 1.0` with the variable and value you want.
 
-### Physics tuning
+## Physics tuning
 
 |Tuning|	Description|	Default|  Unit|
 | ------ | ---------- | -------- | ----- |
@@ -28,7 +28,7 @@ where you replace `gravity 1.0` with the variable and value you want.
 |`player_collision`|	Enable player collisions|	1|
 |`player_hooking`|	Enable player vs player hooking|	1|
 
-### Weapon tuning
+## Weapon tuning
 
 |Tuning	|Description|	Default|  Unit|
 | ------ | ---------- | -------- | ----- |

--- a/support/faq.md
+++ b/support/faq.md
@@ -1,6 +1,6 @@
 # FAQ
 
-### Running the game
+## Running the game
 
 **Q: The game does not start on Windows, I get a "VCRUNTIME140.dll was not found" error**
 
@@ -33,7 +33,7 @@ You are running a 64-bit application on a 32-bit system. [Download Teeworlds for
 **A:** You may want to enable raw mouse input. Open the user console (`f1` by default) and write `inp_grab 1`.
 
 
-### Server related
+## Server related
 
 **Q: How do I setup a server?**
 
@@ -58,7 +58,7 @@ You are running a 64-bit application on a 32-bit system. [Download Teeworlds for
 - Make sure you use a map that is in the data/maps-folder in the teeworlds directory, otherwise it wont work.
 - Make sure the port isn't used.
 
-### Hacking the source
+## Hacking the source
 
 **Q: How do I compile the source?**
 


### PR DESCRIPTION
Fix all headers so the first headlines is always at level 1 and child headlines are always exactly 1 level below their parent.

Remove obsolete compiling_everything document. The contents of this file in the repository have already been split into separate compiling_everything files. The online version at https://www.teeworlds.com/?page=docs&wiki=compiling_everything is already identical to https://www.teeworlds.com/?page=docs&wiki=hacking.